### PR TITLE
fix root project plugin requirement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ gradlePlugin {
             id = "dev.poolside.gradle.semantic-version"
             group = "dev.poolside.gradle.semanticversion"
             implementationClass = "dev.poolside.gradle.semanticversion.SemanticVersionPlugin"
-            version = "0.2.0"
+            version = "0.2.1"
             displayName = "Poolside Semantic Version Plugin"
             description = "Based on a given major.minor version, plugin determines patch version based on what is already " +
                     "maven repository by auto incrementing it to produce the next version number. Major or minor versions " +

--- a/src/main/kotlin/dev/poolside/gradle/semanticversion/SemanticVersionPlugin.kt
+++ b/src/main/kotlin/dev/poolside/gradle/semanticversion/SemanticVersionPlugin.kt
@@ -14,15 +14,11 @@ class SemanticVersionPlugin : Plugin<Project> {
             this.group = "publishing"
             this.manual = extension.manual
         }
-        project.allprojects.forEach { p ->
-            p.tasks.withType<JavaCompile> {
-                this.dependsOn(":semanticVersion")
-            }
+        project.tasks.withType<JavaCompile> {
+            this.dependsOn("semanticVersion")
         }
-        project.allprojects.forEach { p ->
-            p.tasks.withType<GenerateMavenPom> {
-                this.dependsOn(":semanticVersion")
-            }
+        project.tasks.withType<GenerateMavenPom> {
+            this.dependsOn("semanticVersion")
         }
     }
 }


### PR DESCRIPTION
I think this commit added a requirement on the root project needed the plugin installed https://github.com/countableSet/semantic-version-plugin/commit/780d28e7744669cfdadc49fc9576bebed52037a6

seems like a pretty weird requirement, and not really sure what the tests that were added at the time were trying to do. seems like simply adding `apply(plugin = "dev.poolside.gradle.semantic-version")` in the tests fixes the issue 🤔 

anyways, going to release this version and see how it goes